### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+  
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :edit, :show]
 
   def index
-    @item = Item.all.order(created_at: :desc)   
+    @item = Item.all.order(created_at: :desc)
   end
 
   def new
@@ -21,7 +21,7 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
-  
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,6 @@
       <%= link_to item_path(item.id),method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached?%>
-    
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -144,7 +143,7 @@
             <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= item.sale %>円<br><%= item.buy_cost_id %>円</span>
+            <span><%= item.sale %>円<br><%= item.buy_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,10 +128,10 @@
     <ul class='item-lists'>
     <% @item.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+      <%= link_to item_path(item.id),method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached?%>
-
+    
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
+
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
@@ -22,19 +22,19 @@
         <%= @item.buy_cost.name %>
       </span>
     </div>
+      <% if user_signed_in? %>
+      <% if user_signed_in? && current_user.id == @item.user_id %>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+          <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+     <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      
+      <% else %>
+     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% end %>
+    <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -78,7 +78,7 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
+
 
   <div class="comment-box">
     <form>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -102,9 +102,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+    <%= image_tag @item.image, class: "item-box-img" if @item.image.attached?%>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -19,7 +19,7 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.buy_cost.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.buy_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.buy_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -79,7 +79,6 @@
     </div>
   </div>
 
-
   <div class="comment-box">
     <form>
       <textarea class="comment-text"></textarea>
@@ -104,6 +103,7 @@
   </div>
   
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+
 
 </div>
 


### PR DESCRIPTION
 ## What（どのような実装をしているのか）
ユーザの商品詳細表示（編集・削除）

購入者への購入者ボタンの表示
ログイン状態に関わらず出品詳細表示
 ## Why（なぜこの実装が必要なのか）

出品した商品詳細情報が誰にでも表示され、購入ボタンを
表示することにより購入につなげるため

 ## ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/7cd1e2b558a3b0a77206491967bdc52b.gif)](https://gyazo.com/7cd1e2b558a3b0a77206491967bdc52b)

 ## ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/80cbd6d6fee65588cc8ddbd5e0d442f3.gif)](https://gyazo.com/80cbd6d6fee65588cc8ddbd5e0d442f3)

 ## ログアウト状態で、商品詳細ページへ遷移した動画
[![Image from Gyazo](https://i.gyazo.com/51a085098193ad34307e56615a47d853.gif)](https://gyazo.com/51a085098193ad34307e56615a47d853)
